### PR TITLE
Add LuckEnchant

### DIFF
--- a/src/main/java/dev/drawethree/xprison/enchants/model/XPrisonEnchantment.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/XPrisonEnchantment.java
@@ -40,14 +40,12 @@ public abstract class XPrisonEnchantment implements Refundable {
 	private boolean refundEnabled;
 	private int refundGuiSlot;
 	private double refundPercentage;
-	private final LuckEnchant luckEnchant;
 
 	public XPrisonEnchantment(XPrisonEnchants plugin, int id) {
 		this.plugin = plugin;
 		this.id = id;
 		this.reloadDefaultAttributes();
 		this.reload();
-		this.luckEnchant = (LuckEnchant) plugin.getEnchantsRepository().getEnchantById(24);
 	}
 
 	private void reloadDefaultAttributes() {
@@ -81,6 +79,16 @@ public abstract class XPrisonEnchantment implements Refundable {
 	public abstract void onBlockBreak(BlockBreakEvent e, int enchantLevel);
 
 	public abstract double getChanceToTrigger(int enchantLevel);
+
+	public double getChanceToTriggerForPlayer(Player p, int enchantLevel) {
+		double chance = getChanceToTrigger(enchantLevel);
+
+		if(LuckEnchant.isPlayerLucky(p)) {
+			chance *= LuckEnchant.getMultiplier();
+		}
+
+		return chance;
+	}
 
 	public void reload() {
 		this.reloadDefaultAttributes();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/XPrisonEnchantment.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/XPrisonEnchantment.java
@@ -1,6 +1,7 @@
 package dev.drawethree.xprison.enchants.model;
 
 import dev.drawethree.xprison.enchants.XPrisonEnchants;
+import dev.drawethree.xprison.enchants.model.impl.LuckEnchant;
 import dev.drawethree.xprison.pickaxelevels.XPrisonPickaxeLevels;
 import dev.drawethree.xprison.pickaxelevels.model.PickaxeLevel;
 import dev.drawethree.xprison.utils.compat.CompMaterial;
@@ -39,12 +40,14 @@ public abstract class XPrisonEnchantment implements Refundable {
 	private boolean refundEnabled;
 	private int refundGuiSlot;
 	private double refundPercentage;
+	private final LuckEnchant luckEnchant;
 
 	public XPrisonEnchantment(XPrisonEnchants plugin, int id) {
 		this.plugin = plugin;
 		this.id = id;
 		this.reloadDefaultAttributes();
 		this.reload();
+		this.luckEnchant = (LuckEnchant) plugin.getEnchantsRepository().getEnchantById(24);
 	}
 
 	private void reloadDefaultAttributes() {

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
@@ -47,15 +47,10 @@ public final class BlessingEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double chance = getChanceToTrigger(enchantLevel);
-
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
@@ -49,9 +49,13 @@ public final class BlessingEnchant extends XPrisonEnchantment {
 
         double chance = getChanceToTrigger(enchantLevel);
 
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
@@ -46,14 +46,10 @@ public final class CharityEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
@@ -47,10 +47,13 @@ public final class CharityEnchant extends XPrisonEnchantment {
         }
 
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/ExplosiveEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/ExplosiveEnchant.java
@@ -85,10 +85,13 @@ public final class ExplosiveEnchant extends XPrisonEnchantment {
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long timeStart = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/ExplosiveEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/ExplosiveEnchant.java
@@ -84,14 +84,10 @@ public final class ExplosiveEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long timeStart = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/GangValueFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/GangValueFinderEnchant.java
@@ -41,10 +41,13 @@ public final class GangValueFinderEnchant extends XPrisonEnchantment {
         }
 
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         int amount = (int) createExpression(enchantLevel).evaluate();
         plugin.getCore().getGangs().getGangsManager().getPlayerGang(e.getPlayer()).ifPresent(gang -> gang.setValue(gang.getValue() + amount));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/GangValueFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/GangValueFinderEnchant.java
@@ -40,14 +40,10 @@ public final class GangValueFinderEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         int amount = (int) createExpression(enchantLevel).evaluate();
         plugin.getCore().getGangs().getGangsManager().getPlayerGang(e.getPlayer()).ifPresent(gang -> gang.setValue(gang.getValue() + amount));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/GemFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/GemFinderEnchant.java
@@ -41,10 +41,13 @@ public final class GemFinderEnchant extends XPrisonEnchantment {
         }
 
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
         plugin.getCore().getGems().getGemsManager().giveGems(e.getPlayer(), amount, null, ReceiveCause.MINING);

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/GemFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/GemFinderEnchant.java
@@ -40,14 +40,10 @@ public final class GemFinderEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long amount = (long) createExpression(enchantLevel).evaluate();
         plugin.getCore().getGems().getGemsManager().giveGems(e.getPlayer(), amount, null, ReceiveCause.MINING);

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyFinderEnchant.java
@@ -35,9 +35,13 @@ public final class KeyFinderEnchant extends XPrisonEnchantment {
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
 
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         String randomCmd = this.getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.replace("%player%", e.getPlayer().getName()));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyFinderEnchant.java
@@ -33,15 +33,10 @@ public final class KeyFinderEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         String randomCmd = this.getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.replace("%player%", e.getPlayer().getName()));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyallsEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyallsEnchant.java
@@ -35,9 +35,13 @@ public final class KeyallsEnchant extends XPrisonEnchantment {
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
 
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         String randomCmd = getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.replace("%player%", e.getPlayer().getName()));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyallsEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/KeyallsEnchant.java
@@ -33,16 +33,10 @@ public final class KeyallsEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
-
         String randomCmd = getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.replace("%player%", e.getPlayer().getName()));
     }

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/LayerEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/LayerEnchant.java
@@ -61,15 +61,11 @@ public final class LayerEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
 
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long startTime = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/LayerEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/LayerEnchant.java
@@ -63,9 +63,13 @@ public final class LayerEnchant extends XPrisonEnchantment {
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
 
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long startTime = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/LuckEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/LuckEnchant.java
@@ -1,0 +1,100 @@
+package dev.drawethree.xprison.enchants.model.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import dev.drawethree.xprison.enchants.XPrisonEnchants;
+import dev.drawethree.xprison.enchants.model.XPrisonEnchantment;
+import dev.drawethree.xprison.tokens.XPrisonTokens;
+
+public class LuckEnchant extends XPrisonEnchantment {
+
+    private static final Set<UUID> LUCKY_PLAYERS = new HashSet<>();
+    private double chance;
+    private String onActivateMessage;
+    private String onDeactivateMessage;
+    private boolean disableMessages;
+    private double multiplier;
+
+    public LuckEnchant(XPrisonEnchants instance) {
+        super(instance, 24);
+        this.chance = plugin.getEnchantsConfig().getYamlConfig().getDouble("enchants."+id+".Chance");
+        this.onActivateMessage = plugin.getEnchantsConfig().getYamlConfig().getString("enchants."+id+".OnActivate");
+        this.onDeactivateMessage = plugin.getEnchantsConfig().getYamlConfig().getString("enchants."+id+".OnDeactivate");
+        this.multiplier = plugin.getEnchantsConfig().getYamlConfig().getDouble("enchants."+id+".Multiplier");
+        this.disableMessages = plugin.getEnchantsConfig().getYamlConfig().getBoolean("enchants."+id+".DisableMessages");
+    }
+
+    @Override
+    public void onEquip(Player p, ItemStack pickAxe, int level) {}
+
+    @Override
+    public void onUnequip(Player p, ItemStack pickAxe, int level) {}
+
+    @Override
+    public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
+        if (!this.plugin.getCore().isModuleEnabled(XPrisonTokens.MODULE_NAME)) {
+            return;
+        }
+        if (isPlayerLucky(e.getPlayer())) {
+            return;
+        }
+        double chance = getChanceToTrigger(enchantLevel);
+        if (chance < ThreadLocalRandom.current().nextDouble(100)) {
+            return;
+        }
+        setPlayerLuck(e.getPlayer(), true);
+    }
+
+    @Override
+    public double getChanceToTrigger(int enchantLevel) {
+        return chance * enchantLevel;
+    }
+
+    @Override
+    public void reload() {
+        super.reload();
+        this.chance = plugin.getEnchantsConfig().getYamlConfig().getDouble("enchants."+id+".Chance");
+        this.onActivateMessage = plugin.getEnchantsConfig().getYamlConfig().getString("enchants."+id+".OnActivate");
+        this.onDeactivateMessage = plugin.getEnchantsConfig().getYamlConfig().getString("enchants."+id+".OnDeactivate");
+        this.multiplier = plugin.getEnchantsConfig().getYamlConfig().getDouble("enchants."+id+".Multiplier");
+        this.disableMessages = plugin.getEnchantsConfig().getYamlConfig().getBoolean("enchants."+id+".DisableMessages");
+        LUCKY_PLAYERS.clear();
+    }
+
+    @Override
+    public String getAuthor() {
+        return "blithe_kitsune";
+    }
+
+    public double getMultiplier() {
+        return this.multiplier;
+    }
+
+    public void setPlayerLuck(Player p, boolean isLucky) {
+        if (isLucky) {
+            LUCKY_PLAYERS.add(p.getUniqueId());
+            if (!this.disableMessages) {
+                p.sendMessage(this.onActivateMessage);
+            }
+        } else {
+            if(isPlayerLucky(p)) {
+                if (!this.disableMessages) {
+                    p.sendMessage(this.onDeactivateMessage);
+                }
+                LUCKY_PLAYERS.remove(p.getUniqueId());
+            }
+        }
+    }
+
+    public boolean isPlayerLucky(Player p) {
+        return LUCKY_PLAYERS.contains(p.getUniqueId());
+    }
+    
+}

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/NukeEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/NukeEnchant.java
@@ -68,14 +68,10 @@ public final class NukeEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long startTime = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/NukeEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/NukeEnchant.java
@@ -69,10 +69,13 @@ public final class NukeEnchant extends XPrisonEnchantment {
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long startTime = Time.nowMillis();
         final Player p = e.getPlayer();

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/PrestigeFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/PrestigeFinderEnchant.java
@@ -37,9 +37,13 @@ public final class PrestigeFinderEnchant extends XPrisonEnchantment {
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
         int levels = (int) createExpression(enchantLevel).evaluate();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), commandToExecute.replace("%player%", e.getPlayer().getName()).replace("%amount%", String.valueOf(levels)));
     }

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/PrestigeFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/PrestigeFinderEnchant.java
@@ -36,14 +36,10 @@ public final class PrestigeFinderEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
         int levels = (int) createExpression(enchantLevel).evaluate();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), commandToExecute.replace("%player%", e.getPlayer().getName()).replace("%amount%", String.valueOf(levels)));
     }

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
@@ -34,10 +34,13 @@ public final class SalaryEnchant extends XPrisonEnchantment {
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         double randAmount = createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
@@ -33,14 +33,10 @@ public final class SalaryEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         double randAmount = createExpression(enchantLevel).evaluate();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
@@ -40,14 +40,10 @@ public final class TokenatorEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long randAmount = (long) createExpression(enchantLevel).evaluate();
         plugin.getCore().getTokens().getTokensManager().giveTokens(e.getPlayer(), randAmount, null, ReceiveCause.MINING);

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
@@ -41,10 +41,13 @@ public final class TokenatorEnchant extends XPrisonEnchantment {
         }
 
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         long randAmount = (long) createExpression(enchantLevel).evaluate();
         plugin.getCore().getTokens().getTokensManager().giveTokens(e.getPlayer(), randAmount, null, ReceiveCause.MINING);

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/VoucherFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/VoucherFinderEnchant.java
@@ -38,10 +38,13 @@ public final class VoucherFinderEnchant extends XPrisonEnchantment {
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
         double chance = getChanceToTrigger(enchantLevel);
-
+        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
+            chance *= this.getLuckEnchant().getMultiplier();
+        }
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
+        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         CommandWithChance randomCmd = getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.getCommand().replace("%player%", e.getPlayer().getName()));

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/VoucherFinderEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/VoucherFinderEnchant.java
@@ -37,14 +37,10 @@ public final class VoucherFinderEnchant extends XPrisonEnchantment {
 
     @Override
     public void onBlockBreak(BlockBreakEvent e, int enchantLevel) {
-        double chance = getChanceToTrigger(enchantLevel);
-        if (this.getLuckEnchant().isPlayerLucky(e.getPlayer())) {
-            chance *= this.getLuckEnchant().getMultiplier();
-        }
+        double chance = getChanceToTriggerForPlayer(e.getPlayer(), enchantLevel);
         if (chance < ThreadLocalRandom.current().nextDouble(100)) {
             return;
         }
-        this.getLuckEnchant().setPlayerLuck(e.getPlayer(), false);
 
         CommandWithChance randomCmd = getRandomCommandToExecute();
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), randomCmd.getCommand().replace("%player%", e.getPlayer().getName()));

--- a/src/main/java/dev/drawethree/xprison/enchants/repo/EnchantsRepository.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/repo/EnchantsRepository.java
@@ -57,6 +57,7 @@ public class EnchantsRepository {
 	}
 
 	public void loadDefaultEnchantments() {
+		register(new LuckEnchant(this.plugin));
 		register(new EfficiencyEnchant(this.plugin));
 		register(new UnbreakingEnchant(this.plugin));
 		register(new FortuneEnchant(this.plugin));

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -611,6 +611,27 @@ enchants:
       Enabled: true
       InGuiSlot: 49
       Percentage: 50.0
+  '24':
+    RawName: 'luck'
+    Name: '&6Luck'
+    GuiName: '&6Luck'
+    Material: BOOK
+    Enabled: true
+    InGuiSlot: 50
+    Increase-Cost-by: 6
+    Max: 500
+    Chance: 0.0001
+    Cost: 12
+    OnActivate: 'Are you feeling lucky?'
+    OnDeactivate: 'Your luck wore off.'
+    DisableMessages: false
+    Multiplier: 1.5
+    Description:
+      - 'Chance of increasing the other enchantments percentages'
+    Refund:
+      Enabled: true
+      InGuiSlot: 50
+      Percentage: 50.0
 # Format of every pickaxe that has UPC Enchants on it
 # %Enchant-X% represents the name + level of specific enchant (X = id)
 Pickaxe:
@@ -648,6 +669,7 @@ Pickaxe:
     - '%Enchant-21%'
     - '%Enchant-22%'
     - '%Enchant-23%'
+    - '%Enchant-24%'
 # First Join Pickaxe Settings
 first-join-pickaxe:
   # Should we give this pickaxe to players when they first join?


### PR DESCRIPTION
Context:
https://discord.com/channels/596140141668597783/1235093584408215662

This PR adds the following:

- **`chance`-driven enchantments**: `getChanceToTrigger` is replaced with `getChanceToTriggerForPlayer`, which supports chance modifiers.
- **LuckEnchant**: Similar to `BlockBooster`, with a `LUCKY_PLAYERS` set where players remain for 5 minutes (should duration be configurable?)
- `LUCKY_PLAYERS` receive an increase in all percentages of enchantments that use dynamic values in `getChanceToTrigger`.
- **enchants.yml**:
   - `LuckEnchant` ID = 24
   - `OnActivate`: Message to be sent when chance triggers on `onBlockBreak`.
   - `OnDeactivate`: Message sent to the user when they are removed from `LUCKY_PLAYERS`.
   - `DisableMessages`: Disables `OnActivate` and `OnDeactivate`.
   - `Multiplier`: `chance *= multiplier`

I'm willing to work on this based on any feedback or suggestions.
