### PR TITLE
Add /charitymessage to toggle charity messages

### DIFF
--- a/src/main/java/dev/drawethree/xprison/enchants/XPrisonEnchants.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/XPrisonEnchants.java
@@ -120,6 +120,9 @@ public final class XPrisonEnchants implements XPrisonModule {
 
 		ValueCommand valueCommand = new ValueCommand(this);
 		valueCommand.register();
+
+		ToggleCharityMessagesCommand toggleCharityMessagesCommand = new ToggleCharityMessagesCommand(this);
+		toggleCharityMessagesCommand.register();
 	}
 
 

--- a/src/main/java/dev/drawethree/xprison/enchants/command/ToggleCharityMessagesCommand.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/command/ToggleCharityMessagesCommand.java
@@ -1,0 +1,22 @@
+package dev.drawethree.xprison.enchants.command;
+
+import dev.drawethree.xprison.enchants.XPrisonEnchants;
+import me.lucko.helper.Commands;
+
+public class ToggleCharityMessagesCommand {
+
+	private final XPrisonEnchants plugin;
+
+	public ToggleCharityMessagesCommand(XPrisonEnchants plugin) {
+		this.plugin = plugin;
+	}
+
+	public void register() {
+		Commands.create()
+				.assertPlayer()
+				.handler(c -> {
+					plugin.getEnchantsManager().toggleCharityMessages(c.sender());
+				}).registerAndBind(this.plugin.getCore(), "charitymessages");
+	}
+
+}

--- a/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
@@ -46,10 +46,26 @@ public class EnchantsManager {
 
 	private final XPrisonEnchants plugin;
 	private final List<UUID> lockedPlayers;
+	private final List<UUID> charityMessageOnPlayers;
 
 	public EnchantsManager(XPrisonEnchants plugin) {
 		this.plugin = plugin;
 		this.lockedPlayers = Collections.synchronizedList(new ArrayList<>());
+		this.charityMessageOnPlayers = new ArrayList<>();
+	}
+
+	public void toggleCharityMessages(Player p) {
+		if (this.charityMessageOnPlayers.contains(p.getUniqueId())) {
+			PlayerUtils.sendMessage(p, plugin.getEnchantsConfig().getMessage("charity_messages_disabled"));
+			this.charityMessageOnPlayers.remove(p.getUniqueId());
+		} else {
+			PlayerUtils.sendMessage(p, plugin.getEnchantsConfig().getMessage("charity_messages_enabled"));
+			this.charityMessageOnPlayers.add(p.getUniqueId());
+		}
+	}
+
+	public boolean hasOffCharityMessages(Player p) {
+		return this.charityMessageOnPlayers.contains(p.getUniqueId());
 	}
 
 	public Map<XPrisonEnchantment, Integer> getItemEnchants(ItemStack itemStack) {

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/BlessingEnchant.java
@@ -58,7 +58,7 @@ public final class BlessingEnchant extends XPrisonEnchantment {
         for (Player p : Players.all()) {
             plugin.getCore().getTokens().getTokensManager().giveTokens(p, amount, null, ReceiveCause.MINING_OTHERS);
 
-            if (!this.isMessagesEnabled()) {
+            if (!this.isMessagesEnabled() || plugin.getEnchantsManager().hasOffCharityMessages(p)) {
                 continue;
             }
 

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/CharityEnchant.java
@@ -57,7 +57,7 @@ public final class CharityEnchant extends XPrisonEnchantment {
         for (Player p : Players.all()) {
             plugin.getCore().getEconomy().depositPlayer(p, amount);
 
-            if (!this.isMessagesEnabled()) {
+            if (!this.isMessagesEnabled() || plugin.getEnchantsManager().hasOffCharityMessages(p)) {
                 continue;
             }
 

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -17,6 +17,8 @@ messages:
   enchant_no_level: "&e&l(!) &cYou do not have this enchant!"
   charity_other: "&a&l+ $%amount% &7(From %player%'s Charity)"
   charity_your: "&a&l+ $%amount% &7(From Your Charity)"
+  charity_messages_disabled: "&e&l(!) &7Charity messages are disabled."
+  charity_messages_enabled: "&e&l(!) &7Charity messages are enabled."
   blessing_other: "&6&l+ %amount% TOKENS &7(From %player%'s Blessing)"
   blessing_your: "&6&l+ %amount% TOKENS &7(From Your Blessing)"
   layer_disabled: "&e&l(!) &7You've &c&lDISABLED &7layer."


### PR DESCRIPTION
Instead of disabling the entire charity messages module, this PR adds a new command that works similarly to `/tokenmessage` but for charity messages coming from `BlessingEnchant` (tokens) and `CharityEnchant` (money)

This way players can opt-out of these messages at anytime.