### PR TITLE
Add xprison.tokens.mute for permanent disabling of token messages

### DIFF
--- a/src/main/java/dev/drawethree/xprison/tokens/managers/TokensManager.java
+++ b/src/main/java/dev/drawethree/xprison/tokens/managers/TokensManager.java
@@ -8,6 +8,7 @@ import dev.drawethree.xprison.tokens.api.events.PlayerTokensLostEvent;
 import dev.drawethree.xprison.tokens.api.events.PlayerTokensReceiveEvent;
 import dev.drawethree.xprison.tokens.api.events.XPrisonBlockBreakEvent;
 import dev.drawethree.xprison.tokens.model.BlockReward;
+import dev.drawethree.xprison.tokens.utils.TokensConstants;
 import dev.drawethree.xprison.utils.item.ItemStackBuilder;
 import dev.drawethree.xprison.utils.item.PrisonItem;
 import dev.drawethree.xprison.utils.misc.NumberUtils;
@@ -589,6 +590,9 @@ public class TokensManager {
 	}
 
 	public boolean hasOffTokenMessages(Player p) {
+		if (p.getPlayer().hasPermission(TokensConstants.TOKENS_MUTE_PERM)) {
+			return true;
+		}
 		return !this.tokenMessageOnPlayers.contains(p.getUniqueId());
 	}
 

--- a/src/main/java/dev/drawethree/xprison/tokens/utils/TokensConstants.java
+++ b/src/main/java/dev/drawethree/xprison/tokens/utils/TokensConstants.java
@@ -3,6 +3,7 @@ package dev.drawethree.xprison.tokens.utils;
 public final class TokensConstants {
 
 	public static final String TOKENS_ADMIN_PERM = "xprison.tokens.admin";
+	public static final String TOKENS_MUTE_PERM = "xprison.tokens.mute";
 
 	private TokensConstants() {
 		throw new UnsupportedOperationException("Cannot instantiate.");


### PR DESCRIPTION
Basically `/tokenmessage` but permanent.
Similar to b3cc4bdd88fb39e4602a0d3acf3703629f65ac20 but for tokens.