### PR TITLE
The Pickaxe Update Vol. I

### DIFF
--- a/src/main/java/dev/drawethree/xprison/enchants/XPrisonEnchants.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/XPrisonEnchants.java
@@ -120,6 +120,9 @@ public final class XPrisonEnchants implements XPrisonModule {
 
 		ValueCommand valueCommand = new ValueCommand(this);
 		valueCommand.register();
+
+		ClaimPickaxeCommand claimPickaxeCommand = new ClaimPickaxeCommand(this);
+		claimPickaxeCommand.register();
 	}
 
 

--- a/src/main/java/dev/drawethree/xprison/enchants/command/ClaimPickaxeCommand.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/command/ClaimPickaxeCommand.java
@@ -1,0 +1,65 @@
+package dev.drawethree.xprison.enchants.command;
+
+import dev.drawethree.xprison.enchants.XPrisonEnchants;
+import dev.drawethree.xprison.enchants.managers.CooldownManager;
+import dev.drawethree.xprison.utils.item.PrisonItem;
+import dev.drawethree.xprison.utils.player.PlayerUtils;
+import me.lucko.helper.Commands;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class ClaimPickaxeCommand {
+
+	private static final String COMMAND_NAME = "value";
+
+	private final XPrisonEnchants plugin;
+
+	public ClaimPickaxeCommand(XPrisonEnchants plugin) {
+		this.plugin = plugin;
+	}
+
+
+	public void register() {
+		Commands.create()
+				.assertPlayer()
+				.assertPermission("xprison.claim_pickaxe", this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_no_permission"))
+				.handler(c -> {
+
+					if (!checkCooldown(c.sender())) {
+						PlayerUtils.sendMessage(c.sender(), this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_cooldown").replace("%time%", String.valueOf(this.getCooldownManager().getRemainingTime(c.sender()))));
+						return;
+					}
+
+					ItemStack pickAxe = c.sender().getItemInHand();
+
+					if (!validatePickaxe(pickAxe)) {
+						PlayerUtils.sendMessage(c.sender(), this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_no_pickaxe"));
+						return;
+					}
+
+					PrisonItem item = new PrisonItem(pickAxe);
+					if (!item.getOwnerName().isEmpty()) {
+						PlayerUtils.sendMessage(c.sender(), this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_already_claimed").replace("%owner%", item.getOwnerName()));
+						return;
+					}
+
+					item.setOwnerName(c.sender().getName());
+					pickAxe = item.load();
+
+					plugin.getEnchantsManager().updatePickaxe(c.sender().getPlayer(), pickAxe);
+					PlayerUtils.sendMessage(c.sender(), this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_success"));
+				}).registerAndBind(plugin.getCore(), COMMAND_NAME);
+	}
+
+	private boolean validatePickaxe(ItemStack pickAxe) {
+		return pickAxe != null && this.plugin.getCore().isPickaxeSupported(pickAxe.getType());
+	}
+
+	private boolean checkCooldown(Player sender) {
+		return (sender.isOp() || !getCooldownManager().hasValueCooldown(sender));
+	}
+
+	private CooldownManager getCooldownManager() {
+		return this.plugin.getCooldownManager();
+	}
+}

--- a/src/main/java/dev/drawethree/xprison/enchants/command/ClaimPickaxeCommand.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/command/ClaimPickaxeCommand.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class ClaimPickaxeCommand {
 
-	private static final String COMMAND_NAME = "value";
+	private static final String COMMAND_NAME = "claimpickaxe";
 
 	private final XPrisonEnchants plugin;
 
@@ -38,7 +38,7 @@ public class ClaimPickaxeCommand {
 					}
 
 					PrisonItem item = new PrisonItem(pickAxe);
-					if (!item.getOwnerName().isEmpty()) {
+					if (item.getOwnerName() != null) {
 						PlayerUtils.sendMessage(c.sender(), this.plugin.getEnchantsConfig().getMessage("claim_pickaxe_already_claimed").replace("%owner%", item.getOwnerName()));
 						return;
 					}

--- a/src/main/java/dev/drawethree/xprison/enchants/config/EnchantsConfig.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/config/EnchantsConfig.java
@@ -29,6 +29,7 @@ public class EnchantsConfig {
 	private CompMaterial firstJoinPickaxeMaterial;
 	private List<String> firstJoinPickaxeEnchants;
 	private String firstJoinPickaxeName;
+	private String defaultOwnerName;
 	private boolean keepPickaxesOnDeath;
 	private boolean useUnbreakablePermission;
 	private List<Action> openEnchantMenuActions;
@@ -58,6 +59,7 @@ public class EnchantsConfig {
 		this.firstJoinPickaxeMaterial = CompMaterial.fromString(getYamlConfig().getString("first-join-pickaxe.material"));
 		this.firstJoinPickaxeEnchants = getYamlConfig().getStringList("first-join-pickaxe.enchants");
 		this.firstJoinPickaxeName = getYamlConfig().getString("first-join-pickaxe.name");
+		this.defaultOwnerName = getYamlConfig().getString("default-owner-name");
 		this.keepPickaxesOnDeath = getYamlConfig().getBoolean("keep-pickaxes-on-death");
 		this.useUnbreakablePermission = getYamlConfig().getBoolean("use-unbreakable-permission");
 	}
@@ -108,6 +110,10 @@ public class EnchantsConfig {
 
 	public String getFirstJoinPickaxeName() {
 		return firstJoinPickaxeName;
+	}
+
+	public String getDefaultOwnerName() {
+		return defaultOwnerName;
 	}
 
 	public boolean isKeepPickaxesOnDeath() {

--- a/src/main/java/dev/drawethree/xprison/enchants/config/EnchantsConfig.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/config/EnchantsConfig.java
@@ -59,7 +59,7 @@ public class EnchantsConfig {
 		this.firstJoinPickaxeMaterial = CompMaterial.fromString(getYamlConfig().getString("first-join-pickaxe.material"));
 		this.firstJoinPickaxeEnchants = getYamlConfig().getStringList("first-join-pickaxe.enchants");
 		this.firstJoinPickaxeName = getYamlConfig().getString("first-join-pickaxe.name");
-		this.defaultOwnerName = getYamlConfig().getString("default-owner-name");
+		this.defaultOwnerName = getYamlConfig().getString("Pickaxe.default-owner-name");
 		this.keepPickaxesOnDeath = getYamlConfig().getBoolean("keep-pickaxes-on-death");
 		this.useUnbreakablePermission = getYamlConfig().getBoolean("use-unbreakable-permission");
 	}

--- a/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
@@ -90,6 +90,7 @@ public class EnchantsManager {
 		long blocksBroken = getBlocksBroken(item);
 		final PrisonItem prisonItem = new PrisonItem(item);
 		Map<XPrisonEnchantment, Integer> enchants = prisonItem.getEnchants(getEnchantsRepository());
+		String owner = prisonItem.getOwnerName();
 
 		List<String> pickaxeLore = this.plugin.getEnchantsConfig().getPickaxeLore();
 
@@ -128,11 +129,7 @@ public class EnchantsManager {
 		for (String s : pickaxeLore) {
 			s = s.replace("%Blocks%", String.valueOf(blocksBroken));
 			s = s.replace("%Durability%", durability);
-			if (prisonItem.getOwnerName() == null) {
-				s = s.replace("%PickaxeOwner%", plugin.getEnchantsConfig().getDefaultOwnerName());
-			} else {
-				s = s.replace("%PickaxeOwner%", prisonItem.getOwnerName());
-			}
+			s = s.replace("%PickaxeOwner%", owner == null ? this.plugin.getEnchantsConfig().getDefaultOwnerName() : owner);
 
 			if (pickaxeLevels) {
 				s = s.replace("%Blocks_Required%", nextLevel == null ? "∞" : String.valueOf(nextLevel.getBlocksRequired()));
@@ -587,16 +584,17 @@ public class EnchantsManager {
 			pickaxe = this.setEnchantLevel(target, pickaxe, entry.getKey(), entry.getValue());
 		}
 
+		final PrisonItem pItem = new PrisonItem(pickaxe);
+		pItem.setOwnerName(target.getName());
+		// TODO: Add an extra validation layer by checking if level is configured in pickaxe-levels.yml
 		if (level > 0) {
-			// TODO: Add an extra validation layer by checking if level is configured in pickaxe-levels.yml
-			final PrisonItem pItem = new PrisonItem(pickaxe);
 			pItem.setLevel(level);
-			pItem.setOwnerName(target.getName());
-			if (blocks > 0) {
-				pItem.addBrokenBlocks(blocks);
-			}
-			pickaxe = pItem.load();
 		}
+		// TODO: Calculate level based on broken blocks
+		if (blocks > 0) {
+			pItem.addBrokenBlocks(blocks);
+		}
+		pickaxe = pItem.load();
 
 		pickaxe = this.applyLoreToPickaxe(target, pickaxe);
 

--- a/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
@@ -128,6 +128,7 @@ public class EnchantsManager {
 		for (String s : pickaxeLore) {
 			s = s.replace("%Blocks%", String.valueOf(blocksBroken));
 			s = s.replace("%Durability%", durability);
+			s = s.replace("%PickaxeOwner%", prisonItem.getOwnerName());
 
 			if (pickaxeLevels) {
 				s = s.replace("%Blocks_Required%", nextLevel == null ? "∞" : String.valueOf(nextLevel.getBlocksRequired()));

--- a/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
@@ -128,7 +128,11 @@ public class EnchantsManager {
 		for (String s : pickaxeLore) {
 			s = s.replace("%Blocks%", String.valueOf(blocksBroken));
 			s = s.replace("%Durability%", durability);
-			s = s.replace("%PickaxeOwner%", prisonItem.getOwnerName());
+			if (prisonItem.getOwnerName() == null) {
+				s = s.replace("%PickaxeOwner%", "None");
+			} else {
+				s = s.replace("%PickaxeOwner%", prisonItem.getOwnerName());
+			}
 
 			if (pickaxeLevels) {
 				s = s.replace("%Blocks_Required%", nextLevel == null ? "∞" : String.valueOf(nextLevel.getBlocksRequired()));
@@ -569,7 +573,7 @@ public class EnchantsManager {
 		return sum;
 	}
 
-	// /givepickaxe <player> <enchant:18=1;...> <name>
+	// /givepickaxe <player> <enchant:18=1;...> <level> <broken_blocks> <name>
 	public void givePickaxe(Player target, Map<XPrisonEnchantment, Integer> enchants, String pickaxeName, CommandSender sender, int level, int blocks) {
 		ItemStackBuilder pickaxeBuilder = ItemStackBuilder.of(Material.DIAMOND_PICKAXE);
 
@@ -587,6 +591,7 @@ public class EnchantsManager {
 			// TODO: Add an extra validation layer by checking if level is configured in pickaxe-levels.yml
 			final PrisonItem pItem = new PrisonItem(pickaxe);
 			pItem.setLevel(level);
+			pItem.setOwnerName(target.getName());
 			if (blocks > 0) {
 				pItem.addBrokenBlocks(blocks);
 			}
@@ -622,6 +627,10 @@ public class EnchantsManager {
 
 		CompMaterial material = this.plugin.getEnchantsConfig().getFirstJoinPickaxeMaterial();
 		ItemStack item = ItemStackBuilder.of(material.toItem()).name(pickaxeName).build();
+
+		PrisonItem prisonItem = new PrisonItem(item);
+		prisonItem.setOwnerName(player.getName());
+		item = prisonItem.load();
 
 		List<String> firstJoinPickaxeEnchants = this.plugin.getEnchantsConfig().getFirstJoinPickaxeEnchants();
 

--- a/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/managers/EnchantsManager.java
@@ -129,7 +129,7 @@ public class EnchantsManager {
 			s = s.replace("%Blocks%", String.valueOf(blocksBroken));
 			s = s.replace("%Durability%", durability);
 			if (prisonItem.getOwnerName() == null) {
-				s = s.replace("%PickaxeOwner%", "None");
+				s = s.replace("%PickaxeOwner%", plugin.getEnchantsConfig().getDefaultOwnerName());
 			} else {
 				s = s.replace("%PickaxeOwner%", prisonItem.getOwnerName());
 			}

--- a/src/main/java/dev/drawethree/xprison/nicknames/repo/impl/NicknameRepositoryImpl.java
+++ b/src/main/java/dev/drawethree/xprison/nicknames/repo/impl/NicknameRepositoryImpl.java
@@ -29,7 +29,7 @@ public class NicknameRepositoryImpl implements NicknameRepository {
 
 	@Override
 	public void createTables() {
-		this.database.executeSql("CREATE TABLE IF NOT EXISTS " + UUID_PLAYERNAME_TABLE_NAME + "(UUID varchar(36) NOT NULL UNIQUE, nickname varchar(16) NOT NULL, primary key (UUID))");
+		this.database.executeSql("CREATE TABLE IF NOT EXISTS " + UUID_PLAYERNAME_TABLE_NAME + "(" + UUID_PLAYERNAME_UUID_COLNAME + " varchar(36) NOT NULL UNIQUE, " + UUID_PLAYERNAME_NICK_COLNAME + " varchar(16) NOT NULL, primary key (UUID))");
 	}
 
 	@Override

--- a/src/main/java/dev/drawethree/xprison/pickaxelevels/config/PickaxeLevelsConfig.java
+++ b/src/main/java/dev/drawethree/xprison/pickaxelevels/config/PickaxeLevelsConfig.java
@@ -14,6 +14,7 @@ public class PickaxeLevelsConfig {
 	private final XPrisonPickaxeLevels plugin;
 	private final FileManager.Config config;
 
+	private boolean preventNameOverwrite;
 	private Map<String, String> messages;
 	private Map<Integer, PickaxeLevel> pickaxeLevels;
 	private int progressBarLength;
@@ -41,6 +42,7 @@ public class PickaxeLevelsConfig {
 		this.loadPickaxeLevels();
 		this.progressBarDelimiter = this.getConfig().get().getString("progress-bar-delimiter");
 		this.progressBarLength = this.getConfig().get().getInt("progress-bar-length");
+		this.preventNameOverwrite = this.getConfig().get().getBoolean("prevent-name-overwrite");
 	}
 
 
@@ -113,5 +115,9 @@ public class PickaxeLevelsConfig {
 
 	public String getProgressBarDelimiter() {
 		return progressBarDelimiter;
+	}
+
+	public boolean isPreventingNameOverwrite() {
+		return preventNameOverwrite;
 	}
 }

--- a/src/main/java/dev/drawethree/xprison/pickaxelevels/manager/PickaxeLevelsManager.java
+++ b/src/main/java/dev/drawethree/xprison/pickaxelevels/manager/PickaxeLevelsManager.java
@@ -55,9 +55,23 @@ public class PickaxeLevelsManager {
 		return this.plugin.getPickaxeLevelsConfig().getDefaultLevel();
 	}
 
+	/*
+	 * If flag to prevent name overwrite is enabled it means the item name can be changed by other plugins.
+	 * When enabled, a comparation between current item name and the expected name occurs.
+	 * If the names don't match it means the item has been renamed and therefore name should not be updated by X-Prison.
+	 */
+	private boolean usesPickaxeLevels(ItemStack pickaxe, PickaxeLevel currentLevel, Player player) {
+		if (!plugin.getPickaxeLevelsConfig().isPreventingNameOverwrite()) {
+			return false;
+		}
+		String currentName = pickaxe.getItemMeta().getDisplayName();
+		String expectedName = getDisplayName(currentLevel, player);
+		return currentName.equals(expectedName);
+	}
+
 	public ItemStack setPickaxeLevel(ItemStack item, PickaxeLevel level, Player p) {
 
-		if (level == null || level.getLevel() <= 0 || level.getLevel() > this.getMaxLevel().getLevel()) {
+		if (level == null || level.getLevel() <= 0 || level.getLevel() > this.getMaxLevel().getLevel() || !this.usesPickaxeLevels(item, level, p)) {
 			return item;
 		}
 

--- a/src/main/java/dev/drawethree/xprison/pickaxelevels/manager/PickaxeLevelsManager.java
+++ b/src/main/java/dev/drawethree/xprison/pickaxelevels/manager/PickaxeLevelsManager.java
@@ -60,7 +60,7 @@ public class PickaxeLevelsManager {
 	 * When enabled, a comparation between current item name and the expected name occurs.
 	 * If the names don't match it means the item has been renamed and therefore name should not be updated by X-Prison.
 	 */
-	private boolean usesPickaxeLevels(ItemStack pickaxe, PickaxeLevel currentLevel, Player player) {
+	private boolean usesPickaxeLevelNames(ItemStack pickaxe, PickaxeLevel currentLevel, Player player) {
 		if (!plugin.getPickaxeLevelsConfig().isPreventingNameOverwrite()) {
 			return false;
 		}
@@ -71,14 +71,14 @@ public class PickaxeLevelsManager {
 
 	public ItemStack setPickaxeLevel(ItemStack item, PickaxeLevel level, Player p) {
 
-		if (level == null || level.getLevel() <= 0 || level.getLevel() > this.getMaxLevel().getLevel() || !this.usesPickaxeLevels(item, level, p)) {
+		if (level == null || level.getLevel() <= 0 || level.getLevel() > this.getMaxLevel().getLevel()) {
 			return item;
 		}
 
 		final PrisonItem prisonItem = new PrisonItem(item);
 		prisonItem.setLevel(level.getLevel());
 		ItemStackBuilder builder = ItemStackBuilder.of(prisonItem.loadCopy());
-		if (level.getDisplayName() != null && !level.getDisplayName().isEmpty()) {
+		if (level.getDisplayName() != null && !level.getDisplayName().isEmpty() && usesPickaxeLevelNames(item, level, p)) {
 			builder = builder.name(this.getDisplayName(level, p));
 		}
 

--- a/src/main/java/dev/drawethree/xprison/utils/item/PrisonItem.java
+++ b/src/main/java/dev/drawethree/xprison/utils/item/PrisonItem.java
@@ -45,6 +45,10 @@ public class PrisonItem extends RtagItem {
         return get(MAIN, "tokens");
     }
 
+    public String getOwnerName() {
+        return get(MAIN, "owner");
+    }
+
     public void setEnchant(XPrisonEnchantment enchant, int level) {
         if (level > 0) {
             set(level, MAIN, "enchants", String.valueOf(enchant.getId()));
@@ -63,6 +67,10 @@ public class PrisonItem extends RtagItem {
 
     public void setTokens(long amount) {
         set(amount, MAIN, "tokens");
+    }
+
+    public void setOwnerName(String name) {
+        set(name, MAIN, "owner");
     }
 
     public void addBrokenBlocks(int amount) {

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -30,7 +30,7 @@ messages:
   value_value: "&e&lVALUE &8» &f%player%'s &7Pickaxe Value: &f%tokens% Tokens&7."
   value_cooldown: "&e&lVALUE &8» &7Please wait &f%time% Seconds&7 before using this command again."
   claim_pickaxe_no_permission: "&e&lPICKAXE &8» &cYou do not have permission to claim pickaxes."
-  claim_pickaxe_cooldown: "&e&lPICKAXE &8» &cYou must wait &f%time% &cbefore running this command again."
+  claim_pickaxe_cooldown: "&e&lPICKAXE &8» &cYou must wait &f%time% seconds &cbefore running this command again."
   claim_pickaxe_no_pickaxe: "&e&lPICKAXE &8» &cCouldn't find a pickaxe. Perhaps you should hold one?"
   claim_pickaxe_already_claimed: "&e&lPICKAXE &8» &cThis pickaxe is already claimed by %owner%."
   claim_pickaxe_success: "&e&lPICKAXE &8» &7You have successfully claimed this pickaxe."

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -29,6 +29,11 @@ messages:
   value_no_pickaxe: "&e&lVALUE &8» &7You must hold an pickaxe in your hand."
   value_value: "&e&lVALUE &8» &f%player%'s &7Pickaxe Value: &f%tokens% Tokens&7."
   value_cooldown: "&e&lVALUE &8» &7Please wait &f%time% Seconds&7 before using this command again."
+  claim_pickaxe_no_permission: "&e&lPICKAXE &8» &cYou do not have permission to claim pickaxes."
+  claim_pickaxe_cooldown: "&e&lPICKAXE &8» &cYou must wait &f%time% &cbefore running this command again."
+  claim_pickaxe_no_pickaxe: "&e&lPICKAXE &8» &cCouldn't find a pickaxe. Perhaps you should hold one?"
+  claim_pickaxe_already_claimed: "&e&lPICKAXE &8» &cThis pickaxe is already claimed by %owner%."
+  claim_pickaxe_success: "&e&lPICKAXE &8» &7You have successfully claimed this pickaxe."
   pickaxe_given: "&e&lENCHANT &8» &fYou have given pickaxe to &e%player%"
   pickaxe_received: "&e&lENCHANT &8» &fYou have received pickaxe from &e%sender%"
   pickaxe_inventory_full: "&e&lENCHANT &8» &e%player% &chas full inventory!"
@@ -636,6 +641,7 @@ enchants:
 # Format of every pickaxe that has UPC Enchants on it
 # %Enchant-X% represents the name + level of specific enchant (X = id)
 Pickaxe:
+  persist-external-lore: false
   # NUMBER = All levels as numbers
   # ROMAN = All levels as roman numbers
   # FIXED = First 10 levels as roman,
@@ -643,6 +649,7 @@ Pickaxe:
   excluded-format: "&7[&c-&7] &8%Enchant% %Level%"
   lore:
     - '&8&m------------------------'
+    - '&e&lOWNER: &f%PickaxeOwner%'
     - '&e&lBLOCKS MINED: &f%Blocks%/%Blocks_Required%'
     - '&e&lPICKAXE LEVEL: &f%PickaxeLevel% &7[%PickaxeProgress%&7]'
     - '&e&lDURABILITY: &f%Durability%'

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -641,12 +641,12 @@ enchants:
 # Format of every pickaxe that has UPC Enchants on it
 # %Enchant-X% represents the name + level of specific enchant (X = id)
 Pickaxe:
-  persist-external-lore: false
   # NUMBER = All levels as numbers
   # ROMAN = All levels as roman numbers
   # FIXED = First 10 levels as roman,
   level-format: NUMBER
   excluded-format: "&7[&c-&7] &8%Enchant% %Level%"
+  default-owner-name: "&4Unclaimed"
   lore:
     - '&8&m------------------------'
     - '&e&lOWNER: &f%PickaxeOwner%'

--- a/src/main/resources/pickaxe-levels.yml
+++ b/src/main/resources/pickaxe-levels.yml
@@ -17,6 +17,7 @@ levels:
 progress-bar-delimiter: ":"
 # Length of progress bar
 progress-bar-length: 20
+prevent-name-overwrite: false
 messages:
   pickaxe-level-up: "&e&lPICKAXE &8» &7Your current pickaxe just leveled up to &eLevel %level%&7!"
   pickaxe-progress: "&e&lPICKAXE &8» &7Current progress: &c%blocks%&7/&a%blocks_required% Blocks"


### PR DESCRIPTION
Been working on a few QOL changes for Pickaxes and this happens to be the first list:

- Allowing Pickaxe to store the owner name in `PrisonItem` + `RTag`, it's available as `%PickaxeOwner%` inside `enchants.yml`.
-  `/givepickaxe` and `/givefirstjoinerpickaxe` now set the owner.
- Add `/claimpickaxe` along with `xprison.claim_pickaxe` so users can claim their pickaxes manually. (only if there's no previous owner)
- Add `prevent-name-overwrite` in `pickaxe-levels.yml` so whenever this flag is set to `true` it will verify if the item name has changed, if so then it won't overwrite with the current pickaxe level.