### PR TITLE
Vanished players leak

### DIFF
--- a/src/main/java/dev/drawethree/xprison/gems/commands/GemsPayCommand.java
+++ b/src/main/java/dev/drawethree/xprison/gems/commands/GemsPayCommand.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class GemsPayCommand extends GemsCommand {
 
@@ -69,7 +68,11 @@ public final class GemsPayCommand extends GemsCommand {
 		List<String> list = new ArrayList<>();
 
 		if (args.size() == 1) {
-			list = Players.all().stream().map(Player::getName).collect(Collectors.toList());
+			for (Player player : Players.all()) {
+				if (!player.hasPermission("xprison.vanish")) {
+					list.add(player.getName());
+				}
+			}
 		}
 
 		return list;

--- a/src/main/java/dev/drawethree/xprison/tokens/commands/TokensPayCommand.java
+++ b/src/main/java/dev/drawethree/xprison/tokens/commands/TokensPayCommand.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class TokensPayCommand extends TokensCommand {
 
@@ -70,7 +69,11 @@ public final class TokensPayCommand extends TokensCommand {
 		List<String> list = new ArrayList<>();
 
 		if (args.size() == 1) {
-			list = Players.all().stream().map(Player::getName).collect(Collectors.toList());
+			for (Player player : Players.all()) {
+				if (!player.hasPermission("xprison.vanish")) {
+					list.add(player.getName());
+				}
+			}
 		}
 
 		return list;


### PR DESCRIPTION
Adding `xprison.vanish` perm for users to be removed from the tab complete in `/gems pay` and `/tokens pay`. Right now the full list of online players is showing up which includes vanished players and even opped players.