### PR TITLE
feat(TokenatorEnchant,SalaryEnchant): add prestige variable to config

### DIFF
--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/SalaryEnchant.java
@@ -38,7 +38,8 @@ public final class SalaryEnchant extends XPrisonEnchantment {
             return;
         }
 
-        double randAmount = createExpression(enchantLevel).evaluate();
+        long playerPrestige = this.plugin.getCore().getPrestiges().getPrestigeManager().getPlayerPrestige(e.getPlayer()).getId();
+        double randAmount = createExpression(enchantLevel, playerPrestige).evaluate();
 
         plugin.getCore().getEconomy().depositPlayer(e.getPlayer(), randAmount);
 
@@ -60,11 +61,13 @@ public final class SalaryEnchant extends XPrisonEnchantment {
         this.amountToGiveExpression = plugin.getEnchantsConfig().getYamlConfig().getString("enchants." + id + ".Amount-To-Give");
     }
 
-    private Expression createExpression(int level) {
+    private Expression createExpression(int level, long prestige) {
         return new ExpressionBuilder(this.amountToGiveExpression)
                 .variables("level")
+                .variables("prestige")
                 .build()
-                .setVariable("level", level);
+                .setVariable("level", level)
+                .setVariable("prestige", prestige);
     }
 
     @Override

--- a/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
+++ b/src/main/java/dev/drawethree/xprison/enchants/model/impl/TokenatorEnchant.java
@@ -45,7 +45,8 @@ public final class TokenatorEnchant extends XPrisonEnchantment {
             return;
         }
 
-        long randAmount = (long) createExpression(enchantLevel).evaluate();
+        long playerPrestige = this.plugin.getCore().getPrestiges().getPrestigeManager().getPlayerPrestige(e.getPlayer()).getId();
+        long randAmount = (long) createExpression(enchantLevel, playerPrestige).evaluate();
         plugin.getCore().getTokens().getTokensManager().giveTokens(e.getPlayer(), randAmount, null, ReceiveCause.MINING);
     }
 
@@ -61,11 +62,13 @@ public final class TokenatorEnchant extends XPrisonEnchantment {
         this.amountToGiveExpression = plugin.getEnchantsConfig().getYamlConfig().getString("enchants." + id + ".Amount-To-Give");
     }
 
-    private Expression createExpression(int level) {
+    private Expression createExpression(int level, long prestige) {
         return new ExpressionBuilder(this.amountToGiveExpression)
                 .variables("level")
+                .variables("prestige")
                 .build()
-                .setVariable("level", level);
+                .setVariable("level", level)
+                .setVariable("prestige", prestige);
     }
 
     @Override

--- a/src/main/resources/enchants.yml
+++ b/src/main/resources/enchants.yml
@@ -370,7 +370,7 @@ enchants:
     Increase-Cost-by: 35
     Max: 500
     Chance: 0.2
-    Amount-To-Give: "level * 1000"
+    Amount-To-Give: "level * (prestige * 1000)"
     Cost: 35
     Description:
       - '&7&o(( Ability to receive more money while mining ))'
@@ -407,7 +407,7 @@ enchants:
     Increase-Cost-by: 6
     Max: 500
     Chance: 0.2
-    Amount-To-Give: "level * 2"
+    Amount-To-Give: "level * (prestige * 2)"
     Cost: 12
     Description:
       - '&7&o(( Ability to gain more tokens while mining ))'


### PR DESCRIPTION
Adds `prestige` as a variable to the expression used in both `TokenatorEnchant` and `SalaryEnchant` to calculate the random amount to give to the player.

Changes are backward compatible as it still allows the old formula to work while providing the option to increase the rewards given the player prestige.